### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/public/todomvc-common.js
+++ b/public/todomvc-common.js
@@ -131,7 +131,7 @@
 
 	function findRoot() {
 		var base = location.href.indexOf('examples/');
-		return location.href.substr(0, base);
+		return location.href.slice(0, base !== -1 ? base : 0);
 	}
 
 	function getFile(file, callback) {
@@ -208,13 +208,13 @@
 			var sourceLink = sourceLinks.lastElementChild;
 			// Correct link path
 			var href = sourceLink.getAttribute('href');
-			sourceLink.setAttribute('href', href.substr(href.lastIndexOf('http')));
+			sourceLink.setAttribute('href', href.slice(href.lastIndexOf('http')));
 			sourceLinks.innerHTML = heading.outerHTML + sourceLink.outerHTML;
 		} else {
 			// Localize demo links
 			var demoLinks = aside.querySelectorAll('.demo-link');
 			Array.prototype.forEach.call(demoLinks, function (demoLink) {
-				if (demoLink.getAttribute('href').substr(0, 4) !== 'http') {
+				if (demoLink.getAttribute('href').slice(0, 4) !== 'http') {
 					demoLink.setAttribute('href', findRoot() + demoLink.getAttribute('href'));
 				}
 			});


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.