### PR TITLE
Fix: test edit state in submit

### DIFF
--- a/src/TodoMVC.svelte
+++ b/src/TodoMVC.svelte
@@ -75,6 +75,7 @@
 	}
 
 	function submit(event) {
+		if (!editing) return;
 		items[editing].description = event.target.value;
 		editing = null;
 	}


### PR DESCRIPTION
Cancelling edit raises the blur event which runs submit. Sumbit must test if editing is still active.